### PR TITLE
INTERLOK-3587

### DIFF
--- a/src/main/java/com/adaptris/profiler/prometheus/JmxMessageMetricsCollector.java
+++ b/src/main/java/com/adaptris/profiler/prometheus/JmxMessageMetricsCollector.java
@@ -63,10 +63,9 @@ public class JmxMessageMetricsCollector implements MessageMetricsCollector {
       if(this.getProfilerEventClient() == null)
         loadProfilerEventClient();
     
-      ActivityMap eventActivityMap = this.getProfilerEventClient().getEventActivityMap();
-      while(eventActivityMap != null) {
+      List<ActivityMap> eventActivityMaps = this.getProfilerEventClient().getEventActivityMaps();
+      for(ActivityMap eventActivityMap : eventActivityMaps) {
         foundStatistics.add(eventActivityMap);
-        eventActivityMap = this.getProfilerEventClient().getEventActivityMap();
       }
       
       this.notifyListeners(foundStatistics);


### PR DESCRIPTION
## Motivation

The model for the way we store and serve metrics has changed from a Queue back end to an expiring map.
Now when you ask for metrics from the interlok-monitor-agent project you get a list of metrics rather than having to repeatedly ask for the next one.

## Modification

The metrics collector now gets as list of all metrics rather than a single metric for each call.

## Result

Project is no inline with the latest way we store and serve metrics.

